### PR TITLE
Reinstated vendor-file management

### DIFF
--- a/engine/Core.php
+++ b/engine/Core.php
@@ -10,7 +10,25 @@ class Core {
 
         $pos = strpos(ASSUMED_URL, MODULE_ASSETS_TRIGGER);
 
-        if($pos === false) {
+        if (strpos(ASSUMED_URL, 'vendor/')) {     
+
+            $vendor_file_path = explode('vendor/', ASSUMED_URL)[1];
+            $vendor_file_path = '../vendor/'.$vendor_file_path;
+            $content_type = mime_content_type($vendor_file_path);
+
+            if (strpos($vendor_file_path, '.css')) {
+                $content_type = 'text/css';
+            } else {
+                $content_type == 'text/plain';
+            }
+
+            header('Content-type: '.$content_type);
+            $contents = file_get_contents($vendor_file_path);
+            echo $contents;
+            die();
+
+        } elseif($pos === false) {
+
             $this->serve_controller();
         } else {
             $this->serve_module_asset();


### PR DESCRIPTION
Enables the easy self-hosted integration of packages such as TinyMCE into the Trongate Framework. Useful video at https://www.youtube.com/watch?v=oVSDrG4ibrI 

The TinyMCE core package folder structure has changed slightly since the video was published. 

If you decide to self host the TinyMCE core package (all for free) then put it into a directory called 'vendor' in your root directory e.g. 'localhost/project/vendor'. 
Then add the following lines of code into into your template's <head> section:
<script src="vendor/tinymce/js/tinymce/tinymce.min.js"></script>
<script>
tinymce.init({
    selector: 'textarea.user_message',
    plugins: [
        'advlist autolink lists link image charmap print preview anchor',
        'searchreplace visualblocks code fullscreen emoticons',
        'insertdatetime media table paste code help wordcount'
    ],
    toolbar: 'undo redo | formatselect | ' +
        'bold italic backcolor | alignleft aligncenter ' +
        'alignright alignjustify | bullist numlist outdent indent | ' +
        'emoticons | removeformat | help',
    content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }'
});
</script>